### PR TITLE
Do not reset providers if they are set

### DIFF
--- a/eyes.sdk.core/src/main/java/com/applitools/eyes/EyesBase.java
+++ b/eyes.sdk.core/src/main/java/com/applitools/eyes/EyesBase.java
@@ -125,13 +125,18 @@ public abstract class EyesBase {
     }
 
     private void initProviders() {
-        scaleProviderHandler = new SimplePropertyHandler<>();
-        scaleProviderHandler.set(new NullScaleProvider());
-        cutProviderHandler = new SimplePropertyHandler<>();
-        cutProviderHandler.set(new NullCutProvider());
-        positionProvider = new InvalidPositionProvider();
-        viewportSizeHandler = new SimplePropertyHandler<>();
-        viewportSizeHandler.set(null);
+        if (scaleProviderHandler == null) {
+            setScaleRatio(null);
+        }
+        if (cutProviderHandler == null) {
+            setImageCut(null);
+        }
+        if (positionProvider == null) {
+            setPositionProvider(new InvalidPositionProvider());
+        }
+        if (viewportSizeHandler == null) {
+            setExplicitViewportSize(null);
+        }
     }
 
     /**


### PR DESCRIPTION
Method "initProviders" is invoked twice: in constructor and at test start. Previously it performed full reset of all providers, which blocked ability to use custom providers. This fix adds check so that providers are initialized only if they have not been set before.