### PR TITLE
BrowserStack workaround:

### DIFF
--- a/eyes.common.java/src/main/java/com/applitools/eyes/events/SessionEventHandlers.java
+++ b/eyes.common.java/src/main/java/com/applitools/eyes/events/SessionEventHandlers.java
@@ -14,6 +14,15 @@ public class SessionEventHandlers implements ISessionEventHandler {
         eventHandlers.add(handler);
     }
 
+    public void removeEventHandler(ISessionEventHandler handler) {
+        if (handler == this) { return; }
+        eventHandlers.remove(handler);
+    }
+
+    public void clearEventHandlers() {
+        eventHandlers.clear();
+    }
+
     @Override
     public void initStarted() {
         for (ISessionEventHandler currentHandler : eventHandlers) currentHandler.initStarted();
@@ -53,4 +62,5 @@ public class SessionEventHandlers implements ISessionEventHandler {
     public void validationEnded(String autSessionId, String validationId, ValidationResult validationResult) {
         for (ISessionEventHandler currentHandler : eventHandlers) currentHandler.validationEnded(autSessionId, validationId, validationResult);
     }
+
 }

--- a/eyes.sdk.core/src/main/java/com/applitools/eyes/EyesBase.java
+++ b/eyes.sdk.core/src/main/java/com/applitools/eyes/EyesBase.java
@@ -1753,5 +1753,13 @@ public abstract class EyesBase {
         this.sessionEventHandlers.addEventHandler(eventHandler);
     }
 
+    public void removeSessionEventHandler(ISessionEventHandler eventHandler) {
+        this.sessionEventHandlers.removeEventHandler(eventHandler);
+    }
+
+    public void clearSessionEventHandlers(){
+        this.sessionEventHandlers.clearEventHandlers();
+    }
+
     protected abstract String getAUTSessionId();
 }

--- a/eyes.selenium.java/src/main/java/com/applitools/eyes/selenium/Eyes.java
+++ b/eyes.selenium.java/src/main/java/com/applitools/eyes/selenium/Eyes.java
@@ -1019,8 +1019,9 @@ public class Eyes extends EyesBase {
         FrameChain originalFC = driver.getFrameChain().clone();
         FrameChain fc = driver.getFrameChain().clone();
         while (fc.size() > 0) {
-            driver.getRemoteWebDriver().switchTo().parentFrame();
+            //driver.getRemoteWebDriver().switchTo().parentFrame();
             Frame frame = fc.pop();
+            EyesTargetLocator.parentFrame(driver.getRemoteWebDriver().switchTo(), fc);
             if (fc.size() == 0) {
                 positionMemento = positionProvider.getState();
             }
@@ -2065,8 +2066,9 @@ public class Eyes extends EyesBase {
                         EyesSeleniumUtils.hideScrollbars(this.driver, 200, rootElementForHidingScrollbars);
                     }
                 }
-                driver.getRemoteWebDriver().switchTo().parentFrame();
+                //driver.getRemoteWebDriver().switchTo().parentFrame();
                 fc.pop();
+                EyesTargetLocator.parentFrame(driver.getRemoteWebDriver().switchTo(), fc);
             }
             this.originalOverflow = EyesSeleniumUtils.hideScrollbars(this.driver, 200, rootElementForHidingScrollbars);
             ((EyesTargetLocator) driver.switchTo()).frames(originalFC);
@@ -2089,7 +2091,8 @@ public class Eyes extends EyesBase {
             while (fc.size() > 0) {
                 Frame frame = fc.pop();
                 frame.returnToOriginalOverflow();
-                driver.getRemoteWebDriver().switchTo().parentFrame();
+                //driver.getRemoteWebDriver().switchTo().parentFrame();
+                EyesTargetLocator.parentFrame(driver.getRemoteWebDriver().switchTo(), fc);
             }
             EyesSeleniumUtils.setOverflow(this.driver, originalOverflow, rootElementForHidingScrollbars);
             ((EyesTargetLocator) driver.switchTo()).frames(originalFC);

--- a/eyes.selenium.java/src/main/java/com/applitools/eyes/selenium/wrappers/EyesTargetLocator.java
+++ b/eyes.selenium.java/src/main/java/com/applitools/eyes/selenium/wrappers/EyesTargetLocator.java
@@ -142,13 +142,33 @@ public class EyesTargetLocator implements WebDriver.TargetLocator {
     public WebDriver parentFrame() {
         logger.verbose("EyesTargetLocator.parentFrame()");
         if (driver.getFrameChain().size() != 0) {
-            logger.verbose("Making preparations..");
+            logger.verbose("Making preparations...");
             driver.getFrameChain().pop();
-            logger.verbose("Done! Switching to parent frame..");
-            targetLocator.parentFrame();
+            logger.verbose("Done! Switching to parent frame...");
+            try {
+                throw new WebDriverException();
+                //targetLocator.parentFrame();
+            } catch (Exception WebDriverException) {
+                targetLocator.defaultContent();
+                for (Frame frame : driver.getFrameChain()) {
+                    targetLocator.frame(frame.getReference());
+                }
+            }
         }
         logger.verbose("Done!");
         return driver;
+    }
+
+    public static void parentFrame(WebDriver.TargetLocator targetLocator, FrameChain frameChainToParent) {
+        try {
+            //throw new WebDriverException();
+            targetLocator.parentFrame();
+        } catch (Exception WebDriverException) {
+            targetLocator.defaultContent();
+            for (Frame frame : frameChainToParent) {
+                targetLocator.frame(frame.getReference());
+            }
+        }
     }
 
     /**
@@ -251,8 +271,7 @@ public class EyesTargetLocator implements WebDriver.TargetLocator {
     }
 
     public void resetScroll() {
-        if (defaultContentPositionMemento != null)
-        {
+        if (defaultContentPositionMemento != null) {
             scrollPosition.restoreState(defaultContentPositionMemento);
         }
     }

--- a/eyes.selenium.java/src/test/java/com.applitools.eyes.selenium/TestSetup.java
+++ b/eyes.selenium.java/src/test/java/com.applitools.eyes.selenium/TestSetup.java
@@ -51,6 +51,11 @@ public abstract class TestSetup implements ITest {
         // Initialize the eyes SDK and set your private API key.
         eyes = new Eyes();
 
+        RemoteSessionEventHandler remoteSessionEventHandler = new RemoteSessionEventHandler(
+                eyes.getLogger(), URI.create("http://localhost:3000/"), "MyAccessKey");
+        remoteSessionEventHandler.setThrowExceptions(false);
+        eyes.addSessionEventHandler(remoteSessionEventHandler);
+
         LogHandler logHandler = new StdoutLogHandler(false);
 
         eyes.setLogHandler(logHandler);
@@ -100,6 +105,10 @@ public abstract class TestSetup implements ITest {
             desiredCaps.setCapability("name", testName + " (" + eyes.getFullAgentId() + ")");
 
             caps.merge(desiredCaps);
+        } else if (seleniumServerUrl.equalsIgnoreCase("http://hub-cloud.browserstack.com/wd/hub")) {
+            seleniumServerUrl = "http://" + System.getenv("BROWSERSTACK_USERNAME") + ":" + System.getenv("BROWSERSTACK_ACCESS_KEY") + "@hub-cloud.browserstack.com/wd/hub";
+            desiredCaps.setCapability("platform", platform);
+            desiredCaps.setCapability("name", testName + " (" + eyes.getFullAgentId() + ")");
         }
 
         this.testName = testName + " " + caps.getBrowserName() + " " + platform;
@@ -134,11 +143,6 @@ public abstract class TestSetup implements ITest {
         eyes.addProperty("ForceFPS", forceFPS ? "true" : "false");
         eyes.addProperty("ScaleRatio", "" + eyes.getScaleRatio());
         eyes.addProperty("Agent ID", eyes.getFullAgentId());
-
-        RemoteSessionEventHandler remoteSessionEventHandler = new RemoteSessionEventHandler(
-                eyes.getLogger(), URI.create("http://localhost:3000/"), "MyAccessKey");
-        remoteSessionEventHandler.setThrowExceptions(false);
-        eyes.addSessionEventHandler(remoteSessionEventHandler);
 
         driver = eyes.open(webDriver,
                 testSuitName,


### PR DESCRIPTION
added workaround for missing switchTo().parentFrame() command in BrowserStack.
added support for testing on BrowserStack.
better place for init RemoteSessionEventsHandler.
added ability to remove and to clear remote session event handlers list.