### PR TITLE
workaround fixes:

### DIFF
--- a/eyes.common.java/src/main/java/com/applitools/utils/GeneralUtils.java
+++ b/eyes.common.java/src/main/java/com/applitools/utils/GeneralUtils.java
@@ -1,6 +1,7 @@
 package com.applitools.utils;
 
 import com.applitools.eyes.EyesException;
+import com.applitools.eyes.Logger;
 
 import java.io.*;
 import java.text.DateFormat;
@@ -10,8 +11,6 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * General purpose utilities.
@@ -28,6 +27,8 @@ public class GeneralUtils {
     @SuppressWarnings("SpellCheckingInspection")
     private static final String DATE_FORMAT_RFC1123 =
             "E, dd MMM yyyy HH:mm:ss 'GMT'";
+
+    private static Logger logger;
 
     private GeneralUtils() {}
 
@@ -204,5 +205,27 @@ public class GeneralUtils {
             throw new EyesException("Failed to read text from resource: ", e);
         }
         return sb.toString();
+    }
+
+    public static void logExceptionStackTrace(Exception ex) {
+        logExceptionStackTrace(logger, ex);
+    }
+
+    public static void logExceptionStackTrace(Logger logger, Exception ex) {
+        ByteArrayOutputStream stream = new ByteArrayOutputStream(2048);
+        PrintWriter writer = new PrintWriter(stream, true);
+        ex.printStackTrace(writer);
+        logger.log(ex.toString());
+        try {
+            logger.log(stream.toString("UTF-8"));
+            writer.close();
+            stream.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void initLogger(Logger logger) {
+        GeneralUtils.logger = logger;
     }
 }

--- a/eyes.sdk.core/src/main/java/com/applitools/eyes/EyesBase.java
+++ b/eyes.sdk.core/src/main/java/com/applitools/eyes/EyesBase.java
@@ -9,7 +9,6 @@ import com.applitools.eyes.diagnostics.ResponseTimeAlgorithm;
 import com.applitools.eyes.events.ISessionEventHandler;
 import com.applitools.eyes.events.SessionEventHandlers;
 import com.applitools.eyes.events.ValidationInfo;
-import com.applitools.eyes.events.ValidationResult;
 import com.applitools.eyes.exceptions.DiffsFoundException;
 import com.applitools.eyes.exceptions.NewTestException;
 import com.applitools.eyes.exceptions.TestFailedException;
@@ -125,6 +124,7 @@ public abstract class EyesBase {
 
         Region.initLogger(logger);
         ImageUtils.initLogger(logger);
+        GeneralUtils.initLogger(logger);
 
         initProviders();
 

--- a/eyes.selenium.java/src/main/java/com/applitools/eyes/selenium/Eyes.java
+++ b/eyes.selenium.java/src/main/java/com/applitools/eyes/selenium/Eyes.java
@@ -2066,7 +2066,6 @@ public class Eyes extends EyesBase {
                         EyesSeleniumUtils.hideScrollbars(this.driver, 200, rootElementForHidingScrollbars);
                     }
                 }
-                //driver.getRemoteWebDriver().switchTo().parentFrame();
                 fc.pop();
                 EyesTargetLocator.parentFrame(driver.getRemoteWebDriver().switchTo(), fc);
             }
@@ -2091,7 +2090,6 @@ public class Eyes extends EyesBase {
             while (fc.size() > 0) {
                 Frame frame = fc.pop();
                 frame.returnToOriginalOverflow();
-                //driver.getRemoteWebDriver().switchTo().parentFrame();
                 EyesTargetLocator.parentFrame(driver.getRemoteWebDriver().switchTo(), fc);
             }
             EyesSeleniumUtils.setOverflow(this.driver, originalOverflow, rootElementForHidingScrollbars);

--- a/eyes.selenium.java/src/main/java/com/applitools/eyes/selenium/EyesSeleniumUtils.java
+++ b/eyes.selenium.java/src/main/java/com/applitools/eyes/selenium/EyesSeleniumUtils.java
@@ -637,7 +637,7 @@ public class EyesSeleniumUtils {
                 }
             }
         } catch (Exception ex) {
-            ex.printStackTrace();
+            GeneralUtils.logExceptionStackTrace(ex);
         }
 
         return region.getSize();

--- a/eyes.selenium.java/src/main/java/com/applitools/eyes/selenium/wrappers/EyesTargetLocator.java
+++ b/eyes.selenium.java/src/main/java/com/applitools/eyes/selenium/wrappers/EyesTargetLocator.java
@@ -145,15 +145,7 @@ public class EyesTargetLocator implements WebDriver.TargetLocator {
             logger.verbose("Making preparations...");
             driver.getFrameChain().pop();
             logger.verbose("Done! Switching to parent frame...");
-            try {
-                throw new WebDriverException();
-                //targetLocator.parentFrame();
-            } catch (Exception WebDriverException) {
-                targetLocator.defaultContent();
-                for (Frame frame : driver.getFrameChain()) {
-                    targetLocator.frame(frame.getReference());
-                }
-            }
+            parentFrame(targetLocator, driver.getFrameChain());
         }
         logger.verbose("Done!");
         return driver;
@@ -161,7 +153,6 @@ public class EyesTargetLocator implements WebDriver.TargetLocator {
 
     public static void parentFrame(WebDriver.TargetLocator targetLocator, FrameChain frameChainToParent) {
         try {
-            //throw new WebDriverException();
             targetLocator.parentFrame();
         } catch (Exception WebDriverException) {
             targetLocator.defaultContent();


### PR DESCRIPTION
added utility function to print an exception's stacktrace to the log.
print the exception to log instead of to standard error.
call the static parentFrame method instead of re-implementing (wrongly) the same logic.