### PR TITLE
Selenium pom update - selenium version update

### DIFF
--- a/eyes.selenium.java/pom.xml
+++ b/eyes.selenium.java/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>[3.0.0, 4.0.0)</version>
+            <version>[3.0.0, 3.14.1]</version>
         </dependency>
         <dependency>
             <groupId>io.appium</groupId>


### PR DESCRIPTION
Selenium published 3.141.0 version with breaking changes, so we limit our current dependency to 3.14.1