### PR TITLE
ProxySettings constructor fix Jersey 1x and 2x

### DIFF
--- a/eyes.connectivity.java.jersey1x/src/main/java/com/applitools/eyes/ProxySettings.java
+++ b/eyes.connectivity.java.jersey1x/src/main/java/com/applitools/eyes/ProxySettings.java
@@ -31,6 +31,6 @@ public class ProxySettings extends AbstractProxySettings {
      * @param uri Uri should start without the scheme
      */
     public ProxySettings(String uri) {
-        super(uri);
+        super(uri,"","");
     }
 }

--- a/eyes.connectivity.java.jersey2x/src/main/java/com/applitools/eyes/ProxySettings.java
+++ b/eyes.connectivity.java.jersey2x/src/main/java/com/applitools/eyes/ProxySettings.java
@@ -9,4 +9,12 @@ public class ProxySettings extends AbstractProxySettings {
     public ProxySettings(String uri, int port) {
         super(uri+":"+port, null, null);
     }
+
+    public ProxySettings(String uri, String username, String password) {
+        super(uri, username, password);
+    }
+
+    public ProxySettings(String uri) {
+        super(uri);
+    }
 }


### PR DESCRIPTION
Allowing ProxySettings init using just a string.