### PR TITLE
Fix android view port issue

### DIFF
--- a/eyes.selenium.java/src/main/java/com/applitools/eyes/selenium/Eyes.java
+++ b/eyes.selenium.java/src/main/java/com/applitools/eyes/selenium/Eyes.java
@@ -326,11 +326,9 @@ public class Eyes extends EyesBase implements IEyes {
 
         screenshotFactory = new EyesWebDriverScreenshotFactory(logger, this.driver);
 
-        ensureViewportSize();
-
         openBase();
 
-        String uaString = sessionStartInfo.getEnvironment().getInferred();
+        String uaString = this.driver.getUserAgent();
         if (uaString != null) {
             if (uaString.startsWith("useragent:")) {
                 uaString = uaString.substring(10);
@@ -348,12 +346,6 @@ public class Eyes extends EyesBase implements IEyes {
 
         this.driver.setRotation(rotation);
         return this.driver;
-    }
-
-    private void ensureViewportSize() {
-        if (this.config.getViewportSize() == null) {
-            this.config.setViewportSize(driver.getDefaultContentViewportSize());
-        }
     }
 
     private void initDriver(WebDriver driver) {


### PR DESCRIPTION
* Remove ensureViewportSize() method after driver initialization

There was an issue with Chrome on Android devices. 
If we are trying to get viewPort size before URL is loaded - physical view size (Browser view) will be returned instead of inner viewPort.
