### PR TITLE
Update App name for Acme tests, add Acme and Duplicates tests to testng config

### DIFF
--- a/eyes.selenium.java/src/test/java/com/applitools/eyes/selenium/TestAcme.java
+++ b/eyes.selenium.java/src/test/java/com/applitools/eyes/selenium/TestAcme.java
@@ -15,7 +15,7 @@ public class TestAcme extends TestSetup {
 
     @Factory(dataProvider = "dp", dataProviderClass = TestDataProvider.class)
     public TestAcme(Capabilities caps, String mode) {
-        super("Eyes Selenium SDK - Test Acme", caps, mode);
+        super("Eyes Selenium SDK - ACME", caps, mode);
         testedPageSize = new RectangleSize(1024,768);
     }
 

--- a/eyes.selenium.java/src/test/java/com/applitools/eyes/selenium/TestSetup.java
+++ b/eyes.selenium.java/src/test/java/com/applitools/eyes/selenium/TestSetup.java
@@ -220,6 +220,7 @@ public abstract class TestSetup implements ITest {
         eyes.setStitchMode(this.stitchMode);
         eyes.setSaveNewTests(false);
         eyes.setBatch(TestDataProvider.batchInfo);
+        eyes.setBranchName("master");
         if (System.getenv("APPLITOOLS_USE_PROXY") != null) {
             eyes.setProxy(new ProxySettings("http://127.0.0.1", 8888));
         }

--- a/eyes.selenium.java/testng.xml
+++ b/eyes.selenium.java/testng.xml
@@ -17,6 +17,9 @@
             <class name="com.applitools.eyes.selenium.TestSeleniumEyesWithNullRunner" />
             <class name="com.applitools.eyes.selenium.TestAcme" />
             <class name="com.applitools.eyes.selenium.TestDuplicates" />
+            <class name="com.applitools.eyes.selenium.TestPageWithHeader" />
+            <class name="com.applitools.eyes.selenium.TestScrollRootElement" />
+            <class name="com.applitools.eyes.selenium.TestScrollRootElementOnSimplePage" />
         </classes>
     </test>
     <test name="Test_VG" parallel="instances">

--- a/eyes.selenium.java/testng.xml
+++ b/eyes.selenium.java/testng.xml
@@ -15,6 +15,8 @@
             <class name="com.applitools.eyes.selenium.TestBatchSequenceName" />
             <class name="com.applitools.eyes.selenium.TestBatchAPI" />
             <class name="com.applitools.eyes.selenium.TestSeleniumEyesWithNullRunner" />
+            <class name="com.applitools.eyes.selenium.TestAcme" />
+            <class name="com.applitools.eyes.selenium.TestDuplicates" />
         </classes>
     </test>
     <test name="Test_VG" parallel="instances">


### PR DESCRIPTION
Results of local run for Duplicates tests - 1 pass, 2 - need baseline(should see baselines in CI run):
https://eyes.applitools.com/app/test-results/00000251830975229132/?accountId=xIpd7EWjhU6cjJzDGrMcUw~~

Results of local run for Acme tests - 1 pass, 1 - need baseline(should see baselines in CI run), 1 -has difference (should be fixed after small SDK update - bug will be created):
https://eyes.applitools.com/app/test-results/00000251830974794327/?accountId=xIpd7EWjhU6cjJzDGrMcUw~~