### PR TITLE
Bugfix trello 1955 visual locators use cut scale providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [vNext]
 ### Fixed
 - UFG tests now finish properly even when being closed after `eyes.check` has finished. [Trello 2000](https://trello.com/c/0EWqP5to)
+- Now using cut provider and scale provider added by the user in the visual locators. [Trello 1955](https://trello.com/c/rhfcRXLV)
 ### Updated
 - DOM snapshot script to 4.0.5. [Trello 2006](https://trello.com/c/a6l6gTf9)
 - Extracted connectivity and ufg dom analyzing to remote repositories. [Trello 2074](https://trello.com/c/pP9VbmKF)

--- a/eyes.sdk.core/src/main/java/com/applitools/eyes/EyesBase.java
+++ b/eyes.sdk.core/src/main/java/com/applitools/eyes/EyesBase.java
@@ -346,6 +346,10 @@ public abstract class EyesBase implements IEyesBase {
         return cutProviderHandler != null && !(cutProviderHandler.get() instanceof NullCutProvider);
     }
 
+    public boolean getIsScaleProviderExplicitlySet() {
+        return scaleProviderHandler != null && !(scaleProviderHandler.get() instanceof NullScaleProvider);
+    }
+
     /**
      * Manually set the scale ratio for the images being validated.
      * @param scaleRatio The scale ratio to use, or {@code null} to reset

--- a/eyes.sdk.core/src/main/java/com/applitools/eyes/FixedCutProvider.java
+++ b/eyes.sdk.core/src/main/java/com/applitools/eyes/FixedCutProvider.java
@@ -20,13 +20,13 @@ public class FixedCutProvider implements CutProvider {
     /**
      *
      * @param header The header to cut in pixels.
-     * @param bottom The bottom to cut in pixels.
+     * @param footer The footer to cut in pixels.
      * @param left The left to cut in pixels.
      * @param right The right to cut in pixels.
      */
-    public FixedCutProvider(int header, int bottom, int left, int right) {
+    public FixedCutProvider(int header, int footer, int left, int right) {
         this.header = header;
-        this.footer = bottom;
+        this.footer = footer;
         this.left = left;
         this.right = right;
     }

--- a/eyes.sdk.core/src/main/java/com/applitools/eyes/FixedCutProvider.java
+++ b/eyes.sdk.core/src/main/java/com/applitools/eyes/FixedCutProvider.java
@@ -20,13 +20,13 @@ public class FixedCutProvider implements CutProvider {
     /**
      *
      * @param header The header to cut in pixels.
-     * @param footer The footer to cut in pixels.
+     * @param bottom The bottom to cut in pixels.
      * @param left The left to cut in pixels.
      * @param right The right to cut in pixels.
      */
-    public FixedCutProvider(int header, int footer, int left, int right) {
+    public FixedCutProvider(int header, int bottom, int left, int right) {
         this.header = header;
-        this.footer = footer;
+        this.footer = bottom;
         this.left = left;
         this.right = right;
     }

--- a/eyes.selenium.java/src/main/java/com/applitools/eyes/selenium/SeleniumEyes.java
+++ b/eyes.selenium.java/src/main/java/com/applitools/eyes/selenium/SeleniumEyes.java
@@ -1845,22 +1845,6 @@ public class SeleniumEyes extends EyesBase implements ISeleniumEyes, IBatchClose
         }
 
         /**
-         * Gets cut provider.
-         * @return the cut provider
-         */
-        public String getCutProvider() {
-            return SeleniumEyes.this.cutProviderHandler.get().getClass().getName();
-        }
-
-        /**
-         * Gets scale provider.
-         * @return the scale provider
-         */
-        public String getScaleProvider() {
-            return SeleniumEyes.this.scaleProviderHandler.get().getClass().getName();
-        }
-
-        /**
          * Gets stitch mode.
          * @return the stitch mode
          */
@@ -1885,8 +1869,8 @@ public class SeleniumEyes extends EyesBase implements ISeleniumEyes, IBatchClose
             if (forceFullPageScreenshot == null) return false;
             return forceFullPageScreenshot;
         }
-    }
 
+    }
     @Override
     public Object getAgentSetup() {
         return new EyesSeleniumAgentSetup();
@@ -1911,5 +1895,17 @@ public class SeleniumEyes extends EyesBase implements ISeleniumEyes, IBatchClose
 
     public UserAgent getUserAgent() {
         return userAgent;
+    }
+
+    /**
+     * Gets scale provider.
+     * @return the scale provider
+     */
+    public ScaleProvider getScaleProvider() {
+        return scaleProviderHandler.get();
+    }
+
+    public CutProvider getCutProvider() {
+        return cutProviderHandler.get();
     }
 }

--- a/eyes.selenium.java/src/main/java/com/applitools/eyes/selenium/locators/SeleniumVisualLocatorsProvider.java
+++ b/eyes.selenium.java/src/main/java/com/applitools/eyes/selenium/locators/SeleniumVisualLocatorsProvider.java
@@ -33,6 +33,14 @@ public class SeleniumVisualLocatorsProvider extends BaseVisualLocatorsProvider {
         UserAgent.parseUserAgentString(uaString, true);
         ImageProvider provider = ImageProviderFactory.getImageProvider(userAgent, eyes, logger, driver);
         BufferedImage image = provider.getImage();
-        return ImageUtils.scaleImage(image, 1 / devicePixelRatio);
+        if (eyes.getIsCutProviderExplicitlySet()) {
+            image = eyes.getCutProvider().cut(image);
+        }
+
+        double scaleRatio = devicePixelRatio;
+        if (eyes.getIsScaleProviderExplicitlySet()) {
+            scaleRatio = eyes.getScaleProvider().getScaleRatio();
+        }
+        return ImageUtils.scaleImage(image, 1 / scaleRatio);
     }
 }

--- a/eyes.selenium.java/src/test/java/com/applitools/eyes/selenium/TestVisualLocators.java
+++ b/eyes.selenium.java/src/test/java/com/applitools/eyes/selenium/TestVisualLocators.java
@@ -1,6 +1,7 @@
 package com.applitools.eyes.selenium;
 
 import com.applitools.eyes.EyesRunner;
+import com.applitools.eyes.FixedCutProvider;
 import com.applitools.eyes.Region;
 import com.applitools.eyes.StdoutLogHandler;
 import com.applitools.eyes.locators.VisualLocator;
@@ -38,15 +39,21 @@ public class TestVisualLocators extends ReportingTestSuite {
         try {
             eyes.open(driver, "Applitools Eyes SDK", "testVisualLocators" + suffix);
             Map<String, List<Region>> result = eyes.locate(VisualLocator.name("applitools_title"));
+            eyes.setImageCut(new FixedCutProvider(11, 0, 2, 0));
+            Map<String, List<Region>> resultCut = eyes.locate(VisualLocator.name("applitools_title"));
             eyes.closeAsync();
+
             Assert.assertEquals(result.size(), 1);
             List<Region> regionList = result.get("applitools_title");
             Assert.assertEquals(regionList.size(), 1);
             Region region = regionList.get(0);
-            Assert.assertEquals(region.getLeft(), 2);
-            Assert.assertEquals(region.getTop(), 11);
-            Assert.assertEquals(region.getWidth(), 173);
-            Assert.assertEquals(region.getHeight(), 58);
+            Assert.assertEquals(region, new Region(2, 11, 173, 58));
+
+            Assert.assertEquals(resultCut.size(), 1);
+            regionList = resultCut.get("applitools_title");
+            Assert.assertEquals(regionList.size(), 1);
+            region = regionList.get(0);
+            Assert.assertEquals(region, new Region(0, 0, 173, 58));
         } finally {
             driver.quit();
             eyes.abortAsync();


### PR DESCRIPTION
https://trello.com/c/rhfcRXLV/1955-bug-low-priority-visuallocators-if-a-cutprovider-was-defined-the-viewport-image-taken-by-the-vl-will-not-consider-it