### PR TITLE
Bugfix trello 2121 fullpage scrolling exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Updated
 - Checking for browserStack specific caps for appEnvironment data. [Trello 2017](https://trello.com/c/3q1wrnYG)
 - Scroll mechanism for Android. Added possibility to scroll with helper library. [Trello 1673](https://trello.com/c/CYbkzXia)
+### Fixed
+- When Y coordinate is smaller than 0 it will be set as 0 to avoid IllegalArgumentException. [Trello 2121](https://trello.com/c/3atHV3Ee)
 
 ## [3.175.0] - 2020-08-26
 ### Fixed

--- a/eyes.appium.java/src/main/java/com/applitools/eyes/appium/AndroidScrollPositionProvider.java
+++ b/eyes.appium.java/src/main/java/com/applitools/eyes/appium/AndroidScrollPositionProvider.java
@@ -175,8 +175,8 @@ public class AndroidScrollPositionProvider extends AppiumScrollPositionProvider 
     public void scrollTo(int startX, int startY, int endX, int endY, boolean shouldCancel) {
         logger.verbose("Trying to scroll from startX: " + startX + " | startY: " + startY + " | endX: " + endX + " | endY: " + endY);
         TouchAction scrollAction = new TouchAction(driver);
-        scrollAction.press(new PointOption().withCoordinates(startX, startY)).waitAction(new WaitOptions().withDuration(Duration.ofMillis(1500)));;
-        scrollAction.moveTo(new PointOption().withCoordinates(endX, endY - contentSize.touchPadding));
+        scrollAction.press(new PointOption().withCoordinates(startX, startY)).waitAction(new WaitOptions().withDuration(Duration.ofMillis(1500)));
+        scrollAction.moveTo(new PointOption().withCoordinates(endX, Math.max(endY - contentSize.touchPadding, 0)));
         if (shouldCancel) {
             scrollAction.cancel();
         } else {

--- a/eyes.appium.java/src/test/java/com/applitools/eyes/appium/android/AndroidXRecyclerViewTest.java
+++ b/eyes.appium.java/src/test/java/com/applitools/eyes/appium/android/AndroidXRecyclerViewTest.java
@@ -6,7 +6,7 @@ import org.testng.annotations.Test;
 
 public class AndroidXRecyclerViewTest extends AndroidTestSetup {
 
-    @Test(groups = "failed") // Coordinate [x=1.0, y=-21.0] is outside of element rect: [0,0][1080,1794]
+    @Test
     public void testAndroidXRecyclerView() {
         eyes.setMatchTimeout(1000);
 


### PR DESCRIPTION
When Y coordinate is smaller than 0 it will be set as 0 to avoid IllegalArgumentException