### PR TITLE
Rfe trello 1449 allow getting viewport size before open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Checking for browserStack specific caps for appEnvironment data. [Trello 2017](https://trello.com/c/3q1wrnYG)
 - Scroll mechanism for Android. Added possibility to scroll with helper library. [Trello 1673](https://trello.com/c/CYbkzXia)
 - Connection with the server is now asynchronous. [Trello 2094](https://trello.com/c/O74dUDxG)
+- Calling `eyes.getViewportSize` returns `null` instead of throwing an exception. [Trello 1449](https://trello.com/c/twHGaW1X)
 ### Fixed
 - When Y coordinate is smaller than 0 it will be set as 0 to avoid IllegalArgumentException. [Trello 2121](https://trello.com/c/3atHV3Ee)
 

--- a/eyes.selenium.java/src/main/java/com/applitools/eyes/selenium/SeleniumEyes.java
+++ b/eyes.selenium.java/src/main/java/com/applitools/eyes/selenium/SeleniumEyes.java
@@ -1483,6 +1483,11 @@ public class SeleniumEyes extends EyesBase implements ISeleniumEyes, IBatchClose
      */
     @Override
     public RectangleSize getViewportSize() {
+        if (!isOpen && driver == null) {
+            logger.log("Called getViewportSize before calling open");
+            return null;
+        }
+
         RectangleSize vpSize;
         if (!EyesDriverUtils.isMobileDevice(driver)) {
             if (imageProvider instanceof MobileScreenshotImageProvider) {

--- a/eyes.selenium.java/src/test/java/com/applitools/eyes/selenium/TestSeleniumEyes.java
+++ b/eyes.selenium.java/src/test/java/com/applitools/eyes/selenium/TestSeleniumEyes.java
@@ -191,4 +191,10 @@ public class TestSeleniumEyes extends ReportingTestSuite {
         Assert.assertEquals(serverConnector.getLogger().getLogHandler(), logHandler);
         Assert.assertEquals(EyesConnectivityUtils.getClient(serverConnector).getLogger().getLogHandler(), logHandler);
     }
+
+    @Test
+    public void testGetViewportSizeBeforeOpen() {
+        Eyes eyes = new Eyes(new ClassicRunner());
+        Assert.assertNull(eyes.getViewportSize());
+    }
 }


### PR DESCRIPTION
https://trello.com/c/twHGaW1X/1449-selenium-3-java-non-static-eyesgetviewportsize-should-return-null-if-called-before-open