### PR TITLE
Avoiding hamburger menu interaction during screen swipe when stitchin…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Updated
+- Avoiding hamburger menu interaction on swipe when capturing screenshot parts of the screen
 - Use touch action to reach top left corner in Appium iOS. [Trello 2083](https://trello.com/c/bz4C8PMw) 
 ### Fixed
 - Calculation viewport size for Android devices. [Trello 2132](https://trello.com/c/CDfbKUV6)

--- a/eyes.appium.java/src/main/java/com/applitools/eyes/appium/AndroidFullPageCaptureAlgorithm.java
+++ b/eyes.appium.java/src/main/java/com/applitools/eyes/appium/AndroidFullPageCaptureAlgorithm.java
@@ -43,7 +43,7 @@ public class AndroidFullPageCaptureAlgorithm extends AppiumFullPageCaptureAlgori
 
         ContentSize contentSize = ((AppiumScrollPositionProvider) scrollProvider).getCachedContentSize();
 
-        int xPos = scrollViewRegion.getLeft() + 1;
+        int xPos = scrollViewRegion.getWidth() - 1;
         Region regionToCrop;
 
         // We need to set position margin to avoid shadow at the top of view


### PR DESCRIPTION
Some apps usually have a hamburger menu on the left of the screen as shown below:
<img src="https://i.stack.imgur.com/t8c6q.gif" alt="drawing" style="width: 100px; height: auto;"/>

Currently, every swipe made to move to the next screenshot part is set to (1,y) where x is always equal to 1. This leads to an unintentionally interaction to the hamburger menu, breaking the swipe action as we can see below:
<img src="https://i.imgur.com/CYYJbbH.png" alt="drawing" style="width: 100px; height: auto;"/>
A possible solution to that is change the static x value coordinate to the expression above `device_width - 1`
The result of the change:

<img src="https://i.imgur.com/01zcQPv.png" alt="drawing" style="width: 100px; height: auto;"/>
