### PR TITLE
change coverage tests to 1 major version for compatibility

### DIFF
--- a/eyes.selenium.java/package.json
+++ b/eyes.selenium.java/package.json
@@ -26,6 +26,6 @@
     "docker:stop": "docker stop selenium && docker rm selenium"
   },
   "dependencies": {
-    "@applitools/sdk-coverage-tests": "latest"
+    "@applitools/sdk-coverage-tests": "^1.0.16"
   }
 }


### PR DESCRIPTION
The latest coverage-tool update has new major version and not compatible with current coverage tests configuration. 