### PR TITLE
Bugfix trello 2307 android system bars exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [vNext]
 ### Fixed
 - Added setApiKey and setProxy to BatchClose. [Trello 2189](https://trello.com/c/SlHH9Ssb)
+### Updated
+- Use default viewport height value if we get an exception after `driver.getSystemBars()` call. [Trello 2307](https://trello.com/c/8VCtSmfN)
 
 ## [3.186.0] - 2020-11-23
 ### Updated

--- a/eyes.appium.java/src/main/java/com/applitools/eyes/appium/EyesAppiumDriver.java
+++ b/eyes.appium.java/src/main/java/com/applitools/eyes/appium/EyesAppiumDriver.java
@@ -76,14 +76,18 @@ public class EyesAppiumDriver extends EyesWebDriver {
 
     private int ensureViewportHeight(int viewportHeight) {
         if (EyesDriverUtils.isAndroid(driver)) {
-            int height = getDeviceHeight();
-            Map<String, Integer> systemBarsHeights = getSystemBarsHeights();
-            for (Integer barHeight : systemBarsHeights.values()) {
-                if (barHeight != null && barHeight < height) {
-                    height -= barHeight;
+            try {
+                int height = getDeviceHeight();
+                Map<String, Integer> systemBarsHeights = getSystemBarsHeights();
+                for (Integer barHeight : systemBarsHeights.values()) {
+                    if (barHeight != null && barHeight < height) {
+                        height -= barHeight;
+                    }
                 }
+                return height;
+            } catch (Exception ignored) {
+                logger.log("WARNING: There was an error while getting system bars height. Using original viewport size");
             }
-            return height;
         }
 
         return viewportHeight;


### PR DESCRIPTION
Catch an exception when `driver.getSystemBars()` is calling and use default viewport height in that case