### PR TITLE
Bugfix trello 2339 system bars exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [vNext]
+### Updated
+- Fill system bars with default method if we encountered exceptions from Appium Client. [Trello 2339](https://trello.com/c/AjbgFdZe)
+
 ## [3.190.5]
 ### Updated
 - Updated logs in visual grid tests to have a test id.

--- a/eyes.appium.java/src/main/java/com/applitools/eyes/appium/EyesAppiumDriver.java
+++ b/eyes.appium.java/src/main/java/com/applitools/eyes/appium/EyesAppiumDriver.java
@@ -72,6 +72,11 @@ public class EyesAppiumDriver extends EyesWebDriver {
         return intRectMap;
     }
 
+    public int getViewportHeight() {
+        Map<String, Long> rectMap = (Map<String, Long>) getCachedSessionDetails().get("viewportRect");
+        return rectMap.get("height").intValue();
+    }
+
     private int ensureViewportHeight(int viewportHeight) {
         if (EyesDriverUtils.isAndroid(driver)) {
             try {

--- a/eyes.appium.java/src/main/java/com/applitools/eyes/appium/EyesAppiumUtils.java
+++ b/eyes.appium.java/src/main/java/com/applitools/eyes/appium/EyesAppiumUtils.java
@@ -171,10 +171,17 @@ public class EyesAppiumUtils {
         systemBarHeights.put(STATUS_BAR, null);
         systemBarHeights.put(NAVIGATION_BAR, null);
 
-        if (EyesDriverUtils.isAndroid(driver)) {
-            fillSystemBarsHeightsMap((AndroidDriver) driver.getRemoteWebDriver(), systemBarHeights);
-        } else {
-            fillSystemBarsHeightsMap(driver, systemBarHeights);
+        try {
+            if (EyesDriverUtils.isAndroid(driver)) {
+                fillSystemBarsHeightsMap((AndroidDriver) driver.getRemoteWebDriver(), systemBarHeights);
+            } else {
+                fillSystemBarsHeightsMap(driver, systemBarHeights);
+            }
+        } catch (Exception ignored) {
+            int statusBarHeight = driver.getStatusBarHeight();
+            int navigationBarHeight = driver.getDeviceHeight() - driver.getViewportHeight() - statusBarHeight;
+            systemBarHeights.put(STATUS_BAR, statusBarHeight);
+            systemBarHeights.put(NAVIGATION_BAR, navigationBarHeight);
         }
 
         return systemBarHeights;

--- a/eyes.appium.java/src/test/java/com/applitools/eyes/appium/android/SystemBarsExceptionTest.java
+++ b/eyes.appium.java/src/test/java/com/applitools/eyes/appium/android/SystemBarsExceptionTest.java
@@ -1,0 +1,52 @@
+package com.applitools.eyes.appium.android;
+
+import com.applitools.eyes.Logger;
+import com.applitools.eyes.appium.Eyes;
+import com.applitools.eyes.appium.EyesAppiumDriver;
+import com.applitools.eyes.appium.EyesAppiumUtils;
+import com.applitools.eyes.utils.ReportingTestSuite;
+import io.appium.java_client.android.AndroidDriver;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import java.util.HashMap;
+import java.util.Map;
+import static org.mockito.Mockito.when;
+
+public class SystemBarsExceptionTest extends ReportingTestSuite {
+
+    private static Map<String, Object> sessionDetails;
+    private static AndroidDriver remoteWebDriver;
+
+    @BeforeClass
+    public static void beforeClass() {
+        sessionDetails = new HashMap<>();
+
+        remoteWebDriver = Mockito.mock(AndroidDriver.class);
+        when(remoteWebDriver.getSessionDetails()).thenReturn(sessionDetails);
+
+        when(remoteWebDriver.getSystemBars()).thenThrow(NullPointerException.class);
+    }
+
+    @Before
+    public void setUp() {
+        sessionDetails.put("statBarHeight", 72L);
+        sessionDetails.put("deviceScreenSize", "1080x1920");
+        HashMap<String, Long> viewportRectMap = new HashMap<>();
+        viewportRectMap.put("width", 1080L);
+        viewportRectMap.put("height", 1708L);
+        sessionDetails.put("viewportRect", viewportRectMap);
+    }
+
+    @Test
+    public void testSystemBars() {
+        EyesAppiumDriver eyesDriver = new EyesAppiumDriver(new Logger(), new Eyes(), remoteWebDriver);
+
+        Map<String, Integer> systemBars = EyesAppiumUtils.getSystemBarsHeights(eyesDriver);
+
+        Assert.assertEquals(systemBars.get("statusBar").intValue(), 72);
+        Assert.assertEquals(systemBars.get("navigationBar").intValue(), 140);
+    }
+}


### PR DESCRIPTION
Fill system bars with default method if we encountered exceptions from Appium Client

* It can happens if used custom old version of Appium server or Appium Java client