### PR TITLE
Bugfix trello 1673 cleanup cached data after check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [vNext]
+### Update
+- Cleanup cached data after check() execution. [Trello 1673](https://trello.com/c/CYbkzXia)
+
 ## [3.191.4]
 ### Fixed
 - Coded regions location is now correct when checking a region. [Trello 2436](https://trello.com/c/spt3lwDk)

--- a/eyes.appium.java/src/main/java/com/applitools/eyes/appium/AppiumScrollPositionProvider.java
+++ b/eyes.appium.java/src/main/java/com/applitools/eyes/appium/AppiumScrollPositionProvider.java
@@ -204,4 +204,9 @@ public abstract class AppiumScrollPositionProvider implements ScrollPositionProv
     protected WebElement getFirstScrollableView() {
         return EyesAppiumUtils.getFirstScrollableView(driver);
     }
+
+    public void cleanupCachedData() {
+        this.contentSize = null;
+        this.firstVisibleChild = null;
+    }
 }

--- a/eyes.appium.java/src/main/java/com/applitools/eyes/appium/Eyes.java
+++ b/eyes.appium.java/src/main/java/com/applitools/eyes/appium/Eyes.java
@@ -495,6 +495,7 @@ public class Eyes extends EyesBase {
 
         ValidationResult validationResult = new ValidationResult();
         validationResult.setAsExpected(result.getAsExpected());
+        ((AppiumScrollPositionProvider) getPositionProvider()).cleanupCachedData();
     }
 
     @Override


### PR DESCRIPTION
Cleanup cached content size and first visible child after check() command execution