### PR TITLE
Update import

### DIFF
--- a/coverage-tests/configuration/java_overrides_universal.js
+++ b/coverage-tests/configuration/java_overrides_universal.js
@@ -18,6 +18,13 @@ module.exports = {
     'should handle check of stale element in frame if selector is preserved': {skip: true}, // Not implemented yet
 
     // They are testing a functionality that no longer exists for the SDK
+    'should return actual viewport size': {skip: true},
     'should set viewport size': {skip: true},
     'should set viewport size on edge legacy': {skip: true},
+
+    // Chrome emulator have minor diffs with JS sdk
+    'should not fail if scroll root is stale on android': {config: {branchName: 'universal-java'}},
+    'check window fully on android chrome emulator on mobile page with horizontal scroll': {config: {branchName: 'universal-java'}},
+    'check window fully on android chrome emulator on mobile page': {config: {branchName: 'universal-java'}},
+
 }

--- a/coverage-tests/genericTestsSuite.xml
+++ b/coverage-tests/genericTestsSuite.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
 
-<suite name="java_coverage_tests" verbose="1" parallel="classes" thread-count="1">
+<suite name="java_coverage_tests" verbose="1" parallel="classes" thread-count="8">
     <listeners>
         <listener class-name="org.testng.reporters.JUnitXMLReporter" />
     </listeners>

--- a/eyes.selenium.java/src/main/java/com/applitools/eyes/selenium/USDKConnection.java
+++ b/eyes.selenium.java/src/main/java/com/applitools/eyes/selenium/USDKConnection.java
@@ -20,7 +20,6 @@ import com.applitools.eyes.selenium.universal.dto.response.CommandCloseResponseD
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.sun.corba.se.impl.orbutil.concurrent.Sync;
 import org.asynchttpclient.Dsl;
 import org.asynchttpclient.ws.WebSocket;
 import org.asynchttpclient.ws.WebSocketListener;


### PR DESCRIPTION
Update java coverage tests overrides with "universal-java" branch for the chrome emulator tests
Set default concurrency to 8 