### PR TITLE
Appium By mapper fallback

### DIFF
--- a/eyes.appium.java/androidTestSuite.xml
+++ b/eyes.appium.java/androidTestSuite.xml
@@ -32,4 +32,9 @@
             <class name="com.applitools.eyes.appium.android.AndroidTestByAll"/>
         </classes>
     </test>
+    <test name="Unit" parallel="classes">
+        <classes>
+            <class name="com.applitools.eyes.appium.unit.TestAppiumCheckSettingsMapper"/>
+        </classes>
+    </test>
 </suite>

--- a/eyes.appium.java/src/main/java/com/applitools/eyes/appium/AppiumSelectorRegionMapper.java
+++ b/eyes.appium.java/src/main/java/com/applitools/eyes/appium/AppiumSelectorRegionMapper.java
@@ -2,6 +2,7 @@ package com.applitools.eyes.appium;
 
 import com.applitools.eyes.EyesException;
 import com.applitools.eyes.selenium.universal.dto.SelectorRegionDto;
+import com.applitools.eyes.selenium.universal.mapper.SelectorRegionMapper;
 import com.applitools.utils.GeneralUtils;
 import io.appium.java_client.AppiumBy;
 import io.appium.java_client.MobileBy;
@@ -66,6 +67,9 @@ public class AppiumSelectorRegionMapper {
       selectorRegionDto.setType("-image");
     } else if (by instanceof AppiumBy.ByCustom) {
       selectorRegionDto.setType("-custom");
+    } // if there are no appium instances, try selenium
+    else {
+      selectorRegionDto = SelectorRegionMapper.toSelectorRegionDto(by);
     }
     return selectorRegionDto;
   }

--- a/eyes.appium.java/src/test/java/com/applitools/eyes/appium/unit/TestAppiumCheckSettingsMapper.java
+++ b/eyes.appium.java/src/test/java/com/applitools/eyes/appium/unit/TestAppiumCheckSettingsMapper.java
@@ -15,6 +15,44 @@ import org.testng.annotations.Test;
 public class TestAppiumCheckSettingsMapper {
 
     @Test
+    public void testAppiumByAllWithSeleniumByMapping() {
+        AppiumCheckSettings checkSettings = Target.region(new ByAll(
+                new By[]{
+                        AppiumBy.id("appiumById"),
+                        By.id("seleniumById"),
+                        AppiumBy.accessibilityId("appiumByAccessibilityId")
+                }
+        ));
+
+        CheckSettingsDto dto = AppiumCheckSettingsMapper.toCheckSettingsDto(checkSettings);
+
+        SelectorRegionDto fallback_fallback = new SelectorRegionDto();
+        fallback_fallback.setSelector("appiumByAccessibilityId");
+        fallback_fallback.setType("accessibility id");
+
+        SelectorRegionDto fallback = new SelectorRegionDto();
+        fallback.setSelector("[id=\"seleniumById\"]");
+        fallback.setType("css selector");
+        fallback.setFallback(fallback_fallback);
+
+        SelectorRegionDto region = new SelectorRegionDto();
+        region.setSelector("appiumById");
+        region.setType("id");
+        region.setFallback(fallback);
+
+        SelectorRegionDto actual = (SelectorRegionDto) dto.getRegion();
+
+        Assert.assertNotNull(dto.getRegion());
+        Assert.assertEquals(actual.getSelector(), region.getSelector());
+        Assert.assertEquals(actual.getType(), region.getType());
+        Assert.assertEquals(actual.getFallback().getSelector(), fallback.getSelector());
+        Assert.assertEquals(actual.getFallback().getType(), fallback.getType());
+        Assert.assertEquals(actual.getFallback().getFallback().getSelector(), fallback_fallback.getSelector());
+        Assert.assertEquals(actual.getFallback().getFallback().getType(), fallback_fallback.getType());
+        Assert.assertNull(actual.getFallback().getFallback().getFallback());
+    }
+
+    @Test
     public void testAppiumByAllMapping() {
         AppiumCheckSettings checkSettings = Target.region(new ByAll(
                 new By[]{
@@ -74,5 +112,44 @@ public class TestAppiumCheckSettingsMapper {
         Assert.assertEquals(actual.getChild().getSelector(), child.getSelector());
         Assert.assertEquals(actual.getChild().getType(), child.getType());
         Assert.assertNull(actual.getChild().getFallback());
+    }
+
+    @Test
+    public void testAppiumByChainedWithSeleniumByMapping() {
+        AppiumCheckSettings checkSettings = Target.region(new ByChained(
+                new By[]{
+                        AppiumBy.id("appiumById"),
+                        By.partialLinkText("seleniumPartialLinkText"),
+                        AppiumBy.xpath("appiumByXpath")
+                }
+        ));
+
+        CheckSettingsDto dto = AppiumCheckSettingsMapper.toCheckSettingsDto(checkSettings);
+
+        SelectorRegionDto child_child = new SelectorRegionDto();
+        child_child.setSelector("appiumByXpath");
+        child_child.setType("xpath");
+        child_child.setChild(null);
+
+        SelectorRegionDto child = new SelectorRegionDto();
+        child.setSelector("seleniumPartialLinkText");
+        child.setType("partial link text");
+        child.setChild(child_child);
+
+        SelectorRegionDto region = new SelectorRegionDto();
+        region.setSelector("appiumById");
+        region.setType("id");
+        region.setChild(child);
+
+        SelectorRegionDto actual = (SelectorRegionDto) dto.getRegion();
+
+        Assert.assertNotNull(dto.getRegion());
+        Assert.assertEquals(actual.getSelector(), region.getSelector());
+        Assert.assertEquals(actual.getType(), region.getType());
+        Assert.assertEquals(actual.getChild().getSelector(), child.getSelector());
+        Assert.assertEquals(actual.getChild().getType(), child.getType());
+        Assert.assertEquals(actual.getChild().getChild().getSelector(), child_child.getSelector());
+        Assert.assertEquals(actual.getChild().getChild().getType(), child_child.getType());
+        Assert.assertNull(actual.getChild().getChild().getChild());
     }
 }

--- a/eyes.selenium.java/SpecificTestsSuite.xml
+++ b/eyes.selenium.java/SpecificTestsSuite.xml
@@ -13,4 +13,9 @@
             <class name="com.applitools.eyes.selenium.TestByAll"/>
         </classes>
     </test>
+    <test name="Unit" parallel="classes">
+        <classes>
+            <class name="com.applitools.eyes.unit.TestSeleniumCheckSettingsMapper"/>
+        </classes>
+    </test>
 </suite>


### PR DESCRIPTION
Add a fallback mechanism to try and parse an `AppiumBy` selector as a Selenium `By` when parsing `checkSettings`.